### PR TITLE
Unit test for wish list

### DIFF
--- a/e-commerce-backend-main/src/test/java/com/revature/services/ProductServiceTests.java
+++ b/e-commerce-backend-main/src/test/java/com/revature/services/ProductServiceTests.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Sort;
 
 import java.util.List;
 import java.util.Optional;
@@ -41,7 +42,7 @@ class ProductServiceTests {
     void findAllTest() {
 
         sut = new ProductService(mockProductRepository, null);
-        Mockito.when(mockProductRepository.findAll()).thenReturn(mockProductList);
+        Mockito.when(mockProductRepository.findAll(Sort.by("id"))).thenReturn(mockProductList);
         Optional<List<Product>> products = Optional.of(sut.findAll());
         Assertions.assertEquals(Optional.of(mockProductList), products);
     }

--- a/e-commerce-backend-main/src/test/java/com/revature/services/WishListServiceTests.java
+++ b/e-commerce-backend-main/src/test/java/com/revature/services/WishListServiceTests.java
@@ -2,6 +2,7 @@ package com.revature.services;
 
 import com.revature.dtos.ProductInfo;
 import com.revature.models.Product;
+import com.revature.models.User;
 import com.revature.repositories.WishListRepository;
 import com.revature.models.WishList;
 import java.util.ArrayList;
@@ -46,9 +47,30 @@ public class WishListServiceTests {
   @Test
   void getWishListTest() {
       sut = new WishListService(mockWishListRepository);
-      Mockito.when(mockWishListRepository.findUserWishList(id)).thenReturn(mockWishList);
+
+      //set up test data: fake products and user
+      Product product1 = new Product(2, 50, 49.99, "test product 1", "testImage.jpg", "test1", "test");
+      Product product2 = new Product(5, 34, 19.50, "test product 2", "testImage2.jpg", "test2", "test");
+      User testUser = new User(1);
+
+      //create wish list to be returned by mocked repo
+      WishList wishListItem1 = new WishList(1, testUser, product1);
+      WishList wishListItem2 = new WishList(2, testUser, product2);
+      List<WishList> returnedWishList = new ArrayList<>();
+      returnedWishList.add(wishListItem1);
+      returnedWishList.add(wishListItem2);
+
+      //return the wish list when mocked repo's method is called
+      Mockito.when(mockWishListRepository.findUserWishList(id)).thenReturn(returnedWishList);
+
+      //create list of products expected to be returned by method
+      List<Product> expected = new ArrayList<>();
+      expected.add(product1);
+      expected.add(product2);
+
+      //test and compare result
       Optional<List<Product>> products = Optional.of(sut.getWishList(id));
-      Assertions.assertEquals(Optional.of(new ArrayList<Product>()), products);
+      Assertions.assertEquals(Optional.of(expected), products);
   }
 
   @Test


### PR DESCRIPTION
Fixing up the unit test for the wish list, so that the mocked repo now returns a proper set of data. Most of the changes to that is just setting up that test data

Fixed up one test for the Product service that my previous PR managed to break.